### PR TITLE
removed unicode strings py2-style to get compatibility with py3.2. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: python
 python:
     - "2.7"
     - "3.3"
+    - "3.2"
     - "3.4"
 script: make test

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Usage
     ... </head>
     ... <body><h1>Hello, world.</h1></body>
     ... </html>"""
-    >>> print toronado.from_string(document)
+    >>> print(toronado.from_string(document))
     <html><head></head><body><h1 style="color: red">Hello, world.</h1></body></html>
 
 Command Line Usage

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],

--- a/tests.py
+++ b/tests.py
@@ -55,7 +55,7 @@ class PropertiesTestCase(TestCase):
             'color: red; font-weight: bold',
         ))
 
-        self.assertIn(u'%s' % (properties,), expected)
+        self.assertIn('%s' % (properties,), expected)
 
     def test_from_string(self):
         properties = Properties.from_string('color: red; font-weight: bold')

--- a/toronado/__init__.py
+++ b/toronado/__init__.py
@@ -151,7 +151,7 @@ def inline(tree):
         if style_attr is not None:
             properties.update(Properties.from_string(style_attr))
 
-        node.attrib['style'] = u'%s' % properties
+        node.attrib['style'] = '%s' % properties
 
 
 def from_string(string):


### PR DESCRIPTION
There is no drawback as the code already used unicode_litterals from **future**. Made explicit the gained py3.2 compatibility in travis and setup
