### PR TITLE
fix for !important priority styles

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -165,6 +165,25 @@ class InlineTestCase(TestCase):
         stylesheet, = tree.cssselect('style')
         self.assertNotIn('inline', stylesheet.attrib)
 
+    def test_important_styles(self):
+        tree = html.document_fromstring("""
+            <html>
+            <head>
+                <style type="text/css">
+                    h1 { color: red !important; }
+                </style>
+            </head>
+            <body>
+                <h1>Hello, world.</h1>
+            </body>
+            </html>
+        """)
+
+        inline(tree)
+
+        heading = tree.cssselect('h1')[0]
+        self.assertEqual(heading.attrib['style'], 'color: red ! important')
+
 
 class ParserTestCase(TestCase):
     document = """

--- a/toronado/__init__.py
+++ b/toronado/__init__.py
@@ -113,6 +113,15 @@ def inline(tree):
         </style>
 
     """
+
+    def _prio_value(p):
+        """
+        Format value and priority of a :class:`cssutils.css.Property`.
+        """
+        if p.priority:
+            return "%s ! %s" % (p.value, p.priority)
+        return p.value
+
     rules = {}
 
     stylesheet_parser = cssutils.CSSParser(log=logging.getLogger('%s.cssutils' % __name__))
@@ -125,7 +134,7 @@ def inline(tree):
             continue
 
         for rule in ifilter(is_style_rule, stylesheet_parser.parseString(stylesheet.text)):
-            properties = dict([(property.name, property.value) for property in rule.style])
+            properties = dict([(property.name, _prio_value(property)) for property in rule.style])
             # XXX: This doesn't handle selectors with odd multiple whitespace.
             for selector in map(text_type.strip, rule.selectorText.split(',')):
                 rule = rules.get(selector, None)


### PR DESCRIPTION
`!important` styles were not working. Here is a pull request for a patch that adds a test for `!important` styles and also fixes the `inline()` method.
