### PR TITLE
Fix empty style blocks

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -184,6 +184,20 @@ class InlineTestCase(TestCase):
         heading = tree.cssselect('h1')[0]
         self.assertEqual(heading.attrib['style'], 'color: red ! important')
 
+    def test_empty_styles(self):
+        tree = html.document_fromstring("""
+            <html>
+            <head>
+                <style type="text/css"></style>
+            </head>
+            <body>
+                <h1>Hello, world.</h1>
+            </body>
+            </html>
+        """)
+
+        inline(tree)
+
 
 class ParserTestCase(TestCase):
     document = """

--- a/toronado/__init__.py
+++ b/toronado/__init__.py
@@ -133,6 +133,9 @@ def inline(tree):
             del stylesheet.attrib['inline']
             continue
 
+        if not stylesheet.text:
+            continue
+
         for rule in ifilter(is_style_rule, stylesheet_parser.parseString(stylesheet.text)):
             properties = dict([(property.name, _prio_value(property)) for property in rule.style])
             # XXX: This doesn't handle selectors with odd multiple whitespace.


### PR DESCRIPTION
Thanks for your work!

I fixed case with empty style block, before that toronado failed:
```
tests.py:199: in test_empty_styles
    inline(tree)
toronado/__init__.py:136: in inline
    for rule in ifilter(is_style_rule, stylesheet_parser.parseString(stylesheet.text)):
/home/naspeh/v/mail/lib/python3.4/site-packages/cssutils/parse.py:148: in parseString
    encodingOverride=encoding)
/home/naspeh/v/mail/lib/python3.4/site-packages/cssutils/css/cssstylesheet.py:355: in _setCssTextWithEncodingOverride
    self.cssText = cssText
/home/naspeh/v/mail/lib/python3.4/site-packages/cssutils/css/cssstylesheet.py:303: in _setCssText
    default=ruleset)
/home/naspeh/v/mail/lib/python3.4/site-packages/cssutils/util.py:461: in _parse
    for token in fulltokenizer:
/home/naspeh/v/mail/lib/python3.4/site-packages/cssutils/tokenize2.py:123: in tokenize
    match = matcher(text)
E   TypeError: expected string or buffer
```