### PR TITLE
Allow passing encoding through to `html.tostring` when using `from_string`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
 - '2.7'
-- '3.3'
-- '3.4'
-- '3.5'
+- '3.6'
+- '3.7'
+- '3.8'
+- '3.9'
 script:
     - make test
     - make lint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 120
 
-[pytest]
+[tool:pytest]
 addopts=--tb=short
 norecursedirs=htmlcov docs node_modules .* *.egg-info{args}
 

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/toronado/__init__.py
+++ b/toronado/__init__.py
@@ -287,7 +287,7 @@ def inline(tree):
         node.attrib['style'] = '%s' % properties
 
 
-def from_string(string):
+def from_string(string, encoding=None):
     tree = html.document_fromstring(string)
     inline(tree)
-    return html.tostring(tree)
+    return html.tostring(tree, encoding=encoding)

--- a/toronado/__init__.py
+++ b/toronado/__init__.py
@@ -20,7 +20,7 @@ if PY3:
     text_type = str
     ifilter = filter
 else:
-    text_type = unicode  # flake8: noqa
+    text_type = unicode  # noqa: F821
     ifilter = __import__('itertools').ifilter
 
 


### PR DESCRIPTION
This allows us to pass through an encoding of `unicode` so that we don't receive a bytestring here
in py3.